### PR TITLE
Client move/DnD, ServerQuery toggle, TeaSpeak poke handling + review fixes

### DIFF
--- a/connector/src/main.rs
+++ b/connector/src/main.rs
@@ -1130,10 +1130,17 @@ async fn run(args: Args) -> Result<()> {
 										}
 										None => {
 											// Still try with raw ids if the client left our view.
+											// Carry through the already-decoded password instead of
+											// dropping it - this path is also used for self-moves
+											// via drag-and-drop, which still need the password to
+											// reach the server when the target channel requires one.
 											Some(OutClientMovePart {
 												client_id: ClientId(clid),
 												channel_id: ChannelId(cid),
-												channel_password: Some(Cow::Borrowed("")),
+												channel_password: Some(match &password {
+													Some(pwd) => Cow::Owned(pwd.clone()),
+													None => Cow::Borrowed(""),
+												}),
 											})
 										}
 									},

--- a/connector/src/main.rs
+++ b/connector/src/main.rs
@@ -17,9 +17,9 @@ use tsclientlib::messages::c2s::{
 	OutChannelAddPermPart, OutChannelClientAddPermPart, OutChannelClientDelPermPart,
 	OutChannelClientPermListRequestPart, OutChannelDelPermPart, OutChannelGroupAddPermPart,
 	OutChannelGroupDelPermPart, OutChannelGroupPermListRequestPart, OutChannelPermListRequestPart,
-	OutClientAddPermPart, OutClientDelPermPart, OutClientPermListRequestPart, OutClientPokeRequestPart,
-	OutCreateDirectoryPart, OutDeleteFilePart, OutFileListRequestPart, OutRenameFilePart,
-	OutSendTextMessagePart, OutServerGroupAddPermPart, OutServerGroupDelPermPart,
+	OutClientAddPermPart, OutClientDelPermPart, OutClientMovePart, OutClientPermListRequestPart,
+	OutClientPokeRequestPart, OutCreateDirectoryPart, OutDeleteFilePart, OutFileListRequestPart,
+	OutRenameFilePart, OutSendTextMessagePart, OutServerGroupAddPermPart, OutServerGroupDelPermPart,
 	OutServerGroupPermListRequestPart,
 };
 use tsclientlib::prelude::*;
@@ -103,6 +103,9 @@ struct ClientInfo {
 	/// haven't been individually granted talk power. Always `true` in a
 	/// non-moderated channel.
 	has_talk_power: bool,
+	/// ServerQuery client (`ClientType::Query`). Always included in the
+	/// snapshot; the UI hides these unless the user enables them per favorite.
+	is_query: bool,
 }
 
 /// Payload for the "serveredit " stdin command - every field is optional so
@@ -573,13 +576,13 @@ fn snapshot(con: &data::Connection) -> Event {
 			has_password: ch.has_password.unwrap_or(false),
 		})
 		.collect::<Vec<_>>();
-	// Bookkeeping includes ServerQuery clients (`ClientType::Query`); hide them
-	// from the channel tree / client lists, and from the online-count fallback
-	// below too, so the number shown never counts a client the list doesn't.
+	// Bookkeeping includes ServerQuery clients (`ClientType::Query`). We always
+	// forward them (with `is_query`) so the UI can toggle visibility live from
+	// a favorite setting without reconnecting. Online counts below still exclude
+	// Query by default so the headline matches the default (hidden) tree.
 	let clients = con
 		.clients
 		.values()
-		.filter(|c| !matches!(c.client_type, ClientType::Query { .. }))
 		.map(|c| {
 			// A channel with no talk power requirement at all (the common
 			// case) is never moderated, so everyone can talk regardless of
@@ -605,19 +608,20 @@ fn snapshot(con: &data::Connection) -> Event {
 				channel_group: c.channel_group.0,
 				server_groups: c.server_groups.iter().map(|g| g.0).collect(),
 				has_talk_power,
+				is_query: matches!(c.client_type, ClientType::Query { .. }),
 			}
 		})
 		.collect::<Vec<_>>();
 
 	// Prefer server-reported counters (GTS/TS `virtualserver_*` via notifyserverupdated)
-	// but never under-report vs. the visible (non-Query) client set (stale
-	// optional_data after joins would otherwise freeze the InfoPanel left number).
-	// `virtualserver_clientsonline` usually includes ServerQuery; subtract the
-	// Query clients we filtered from the list so the headline matches the tree.
+	// but never under-report vs. the non-Query client set (stale optional_data
+	// after joins would otherwise freeze the InfoPanel left number).
+	// `virtualserver_clientsonline` usually includes ServerQuery; subtract them
+	// so the default (Query-hidden) headline matches the default tree.
 	let opt = con.server.optional_data.as_ref();
 	let visible_channels = channels.len() as u64;
-	let visible_clients_count = clients.len() as u16;
-	let query_count = (con.clients.len() as u16).saturating_sub(visible_clients_count);
+	let query_count = clients.iter().filter(|c| c.is_query).count() as u16;
+	let visible_clients_count = (clients.len() as u16).saturating_sub(query_count);
 	let server_clients_online = opt
 		.map(|d| {
 			let without_query = d.client_count.saturating_sub(query_count);
@@ -1093,6 +1097,65 @@ async fn run(args: Args) -> Result<()> {
 								}
 							}
 							Err(_) => emit(&Event::Error { message: format!("Invalid client id: {id}") }),
+						}
+					} else if let Some(rest) = l.strip_prefix("moveclient ") {
+						// Move another client (or self) into a channel: clientmove clid=… cid=…
+						// Optional trailing base64 password, same as `switch`.
+						let mut move_args = rest.trim().splitn(3, ' ');
+						let clid_arg = move_args.next().unwrap_or("");
+						let cid_arg = move_args.next().unwrap_or("");
+						let password_arg = move_args.next();
+						match (clid_arg.parse::<u16>(), cid_arg.parse::<u64>()) {
+							(Ok(clid), Ok(cid)) => {
+								let password = password_arg.and_then(|p| {
+									base64::engine::general_purpose::STANDARD
+										.decode(p)
+										.ok()
+										.and_then(|bytes| String::from_utf8(bytes).ok())
+								});
+								let part = match con.get_state() {
+									Ok(state) => match state.clients.get(&ClientId(clid)) {
+										Some(client) => {
+											let mut part = client.client_move(ChannelId(cid));
+											match &password {
+												Some(pwd) => {
+													part = part.set_password(pwd);
+												}
+												None => {
+													part.channel_password =
+														Some(std::borrow::Cow::Borrowed(""));
+												}
+											}
+											Some(part)
+										}
+										None => {
+											// Still try with raw ids if the client left our view.
+											Some(OutClientMovePart {
+												client_id: ClientId(clid),
+												channel_id: ChannelId(cid),
+												channel_password: Some(Cow::Borrowed("")),
+											})
+										}
+									},
+									Err(e) => {
+										emit(&Event::Error {
+											message: format!("Move client failed: {e}"),
+										});
+										None
+									}
+								};
+								if let Some(part) = part {
+									match part.send_with_result(&mut con) {
+										Ok(handle) => {
+											pending_messages.insert(handle, "Move client".into());
+										}
+										Err(e) => emit(&Event::Error { message: e.to_string() }),
+									}
+								}
+							}
+							_ => emit(&Event::Error {
+								message: format!("Malformed moveclient command: {rest}"),
+							}),
 						}
 					} else if l == "away" || l.starts_with("away ") {
 						let message = l.strip_prefix("away").unwrap_or("").trim();
@@ -2292,6 +2355,23 @@ async fn run(args: Args) -> Result<()> {
 					}
 				}
 				Some(Ok(StreamItem::MessageEvent(msg))) => {
+					// Defense in depth: TeaSpeak/GTS may surface notifyclientpoke as an
+					// unhandled MessageEvent if bookkeeping did not mark it handled.
+					if let InMessage::ClientPoke(poke) = &msg {
+						for part in poke.iter() {
+							emit(&Event::Poke {
+								from: part.invoker_name.clone(),
+								message: part.message.clone().unwrap_or_default(),
+							});
+						}
+					} else if let InMessage::ClientPokeNormal(poke) = &msg {
+						for part in poke.iter() {
+							emit(&Event::Poke {
+								from: part.invoker_name.clone(),
+								message: part.message.clone().unwrap_or_default(),
+							});
+						}
+					}
 					if pending_server_log {
 						if let InMessage::ServerLog(log) = &msg {
 							let lines: Vec<String> = log.iter().map(|part| part.log.clone()).collect();

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -138,6 +138,14 @@ wss.on("connection", (socket: WebSocket) => {
         }
         break;
       }
+      case "moveClient": {
+        const clientId = Number(msg.clientId);
+        const channelId = Number(msg.channelId);
+        if (Number.isFinite(clientId) && Number.isFinite(channelId)) {
+          await connection?.moveClient(clientId, channelId, msg.channelPassword);
+        }
+        break;
+      }
       case "sendChatMessage": {
         await connection?.sendChatMessage(msg.message);
         break;

--- a/gateway/src/ts3/connection.ts
+++ b/gateway/src/ts3/connection.ts
@@ -37,6 +37,8 @@ export interface ClientInfo {
   channelGroup: number;
   serverGroups: number[];
   hasTalkPower: boolean;
+  /** ServerQuery client; UI may hide these unless enabled per favorite. */
+  isQuery: boolean;
 }
 
 export interface GroupEntry {
@@ -252,6 +254,7 @@ export class Ts3Connection {
           channel_group: number;
           server_groups: number[];
           has_talk_power: boolean;
+          is_query?: boolean;
         }
 
         interface RawChannelInfo {
@@ -424,6 +427,7 @@ export class Ts3Connection {
               channelGroup: c.channel_group,
               serverGroups: c.server_groups,
               hasTalkPower: c.has_talk_power,
+              isQuery: Boolean(c.is_query),
             })),
             ownClientId: event.own_client_id ?? 0,
             serverMaxClients: event.server_max_clients ?? 0,
@@ -548,6 +552,14 @@ export class Ts3Connection {
     // so it can safely contain spaces or other characters.
     const passwordArg = channelPassword ? ` ${Buffer.from(channelPassword, "utf8").toString("base64")}` : "";
     this.child?.stdin.write(`switch ${id}${passwordArg}\n`);
+  }
+
+  async moveClient(clientId: number, channelId: number, channelPassword?: string): Promise<void> {
+    const clid = Number(clientId);
+    const cid = Number(channelId);
+    if (!Number.isFinite(clid) || !Number.isFinite(cid)) return;
+    const passwordArg = channelPassword ? ` ${Buffer.from(channelPassword, "utf8").toString("base64")}` : "";
+    this.child?.stdin.write(`moveclient ${clid} ${cid}${passwordArg}\n`);
   }
 
   async getClientConnectionInfo(clientId: number): Promise<void> {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1787,6 +1787,13 @@
   background: var(--row-hover);
 }
 
+.ts-channel-row.ts-drop-target,
+.ts-channel-row.ts-spacer.ts-drop-target {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  outline: 1px dashed var(--accent);
+  outline-offset: -1px;
+}
+
 /* Channel spacers ([cspacer], [*spacer01], …) — GreenTeaSpeak / TS parity */
 .ts-channel-row.ts-spacer {
   position: relative;
@@ -1897,8 +1904,13 @@
 }
 
 .ts-client-row {
+  cursor: grab;
   color: var(--client-text);
   padding-left: 0;
+}
+
+.ts-client-row:active {
+  cursor: grabbing;
 }
 
 .ts-client-row.ts-self {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import "./App.css";
 
 /** Only dismiss on a genuine backdrop click, not a text-selection drag that
@@ -2397,7 +2397,7 @@ function MoveClientDialog({
                   <li key={ch.id}>
                     <button
                       className={`ts-menu-item${current ? " ts-group-assign-current" : ""}`}
-                      disabled={current}
+                      disabled={current || spacer.isSpacer}
                       onClick={() => onSelect(ch.id)}
                     >
                       <span className="ts-menu-item-icon">
@@ -7189,6 +7189,16 @@ function AppInner() {
   const handleMoveClient = (clientId: number, channelId: number) => {
     const client = clients.find((c) => c.id === clientId);
     if (client && client.channel === channelId) return;
+    // Moving yourself (e.g. dragging your own row) is a plain channel join,
+    // not an admin action - route it through the normal switch flow so it
+    // only needs join permission and still prompts for a channel password
+    // when required. The `moveClient` command below is for moving OTHER
+    // clients, which - like the native client - bypasses the target
+    // channel's password for whoever holds the move permission.
+    if (clientId === ownClientId) {
+      handleSwitchChannel(channelId);
+      return;
+    }
     socketRef.current?.send(
       JSON.stringify({
         type: "moveClient",
@@ -7481,14 +7491,22 @@ function AppInner() {
   const showServerQueryClients =
     activeFavoriteId != null &&
     favorites.some((f) => f.id === activeFavoriteId && f.showServerQueryClients);
-  const treeClients = showServerQueryClients ? clients : clients.filter((c) => !c.isQuery);
-  const queryClientCount = clients.reduce((n, c) => n + (c.isQuery ? 1 : 0), 0);
-  const displayClientCount = showServerQueryClients
-    ? serverClientsOnline > 0
-      ? serverClientsOnline + queryClientCount
-      : treeClients.length
-    : serverClientsOnline > 0
-      ? serverClientsOnline
+  // clients can be a large, frequently-unchanged list re-scanned on every
+  // render - including on every "talkers" voice-activity update, which has
+  // nothing to do with the client list itself - so memoize on the inputs
+  // that actually affect the result instead of re-filtering/re-reducing it
+  // every time.
+  const treeClients = useMemo(
+    () => (showServerQueryClients ? clients : clients.filter((c) => !c.isQuery)),
+    [clients, showServerQueryClients]
+  );
+  const queryClientCount = useMemo(
+    () => clients.reduce((n, c) => n + (c.isQuery ? 1 : 0), 0),
+    [clients]
+  );
+  const displayClientCount =
+    serverClientsOnline > 0
+      ? serverClientsOnline + (showServerQueryClients ? queryClientCount : 0)
       : treeClients.length;
   const novaSplash = designTheme === "nova" && !connected;
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -260,12 +260,33 @@ interface Favorite {
   serverPassword: string;
   defaultChannel: string;
   defaultChannelPassword: string;
+  /** When true, ServerQuery clients appear in the channel tree. Default: false. */
+  showServerQueryClients: boolean;
+}
+
+function normalizeFavorite(raw: Partial<Favorite> & Pick<Favorite, "id">): Favorite {
+  return {
+    id: raw.id,
+    bookmarkName: typeof raw.bookmarkName === "string" ? raw.bookmarkName : "",
+    nickname: typeof raw.nickname === "string" ? raw.nickname : "",
+    host: typeof raw.host === "string" ? raw.host : "",
+    serverPassword: typeof raw.serverPassword === "string" ? raw.serverPassword : "",
+    defaultChannel: typeof raw.defaultChannel === "string" ? raw.defaultChannel : "",
+    defaultChannelPassword:
+      typeof raw.defaultChannelPassword === "string" ? raw.defaultChannelPassword : "",
+    showServerQueryClients: raw.showServerQueryClients === true,
+  };
 }
 
 function loadFavorites(): Favorite[] {
   try {
     const raw = localStorage.getItem(FAVORITES_KEY);
-    return raw ? (JSON.parse(raw) as Favorite[]) : [];
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((v): v is Partial<Favorite> & Pick<Favorite, "id"> => v && typeof v.id === "string")
+      .map(normalizeFavorite);
   } catch {
     return [];
   }
@@ -448,6 +469,8 @@ interface ClientInfo {
   channelGroup: number;
   serverGroups: number[];
   hasTalkPower: boolean;
+  /** ServerQuery client; filtered from the tree unless a favorite enables them. */
+  isQuery?: boolean;
 }
 
 interface GroupEntry {
@@ -666,6 +689,27 @@ function ServerIcon() {
 const lastChannelClickBySession = new Map<string, { id: number; at: number }>();
 let switchArmedUntil = 0;
 
+const CLIENT_DRAG_MIME = "application/x-webspeak3-client";
+
+type ClientDragPayload = { clientId: number; channelId: number };
+
+function parseClientDragPayload(raw: string): ClientDragPayload | null {
+  try {
+    const data = JSON.parse(raw) as Partial<ClientDragPayload>;
+    if (
+      typeof data.clientId === "number" &&
+      Number.isFinite(data.clientId) &&
+      typeof data.channelId === "number" &&
+      Number.isFinite(data.channelId)
+    ) {
+      return { clientId: data.clientId, channelId: data.channelId };
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
 function ChannelTree({
   channels,
   clients,
@@ -680,6 +724,7 @@ function ChannelTree({
   onSwitchChannel,
   onOpenPrivateChat,
   onPokeClient,
+  onMoveClient,
   onClientContextMenu,
   onChannelContextMenu,
 }: {
@@ -698,11 +743,13 @@ function ChannelTree({
   onSwitchChannel: (channelId: number) => void;
   onOpenPrivateChat: (clientId: number, clientName: string) => void;
   onPokeClient: (clientId: number, clientName: string) => void;
+  onMoveClient: (clientId: number, channelId: number) => void;
   onClientContextMenu: (e: React.MouseEvent, clientId: number, clientName: string, isSelf: boolean) => void;
   onChannelContextMenu: (e: React.MouseEvent, channelId: number, channelName: string) => void;
 }) {
   const t = useT();
   const [collapsed, setCollapsed] = useState<Set<number>>(() => new Set());
+  const [dragOverChannelId, setDragOverChannelId] = useState<number | null>(null);
   // Module-level click tracking (see lastChannelClick) — refs alone are not
   // enough when Select re-renders remount nested ChannelTree instances.
   const children = channels.filter((c) => c.parent === parent).sort((a, b) => a.order - b.order);
@@ -744,7 +791,7 @@ function ChannelTree({
           <div
             className={`ts-row ts-channel-row${spacerClass}${
               selected?.type === "channel" && selected.id === channel.id ? " ts-row-selected" : ""
-            }`}
+            }${dragOverChannelId === channel.id ? " ts-drop-target" : ""}`}
             onClick={() => {
               onSelectItem({ type: "channel", id: channel.id });
               // Manual double-click: native dblclick is often lost when the first
@@ -765,6 +812,24 @@ function ChannelTree({
               onSwitchChannel(channel.id);
             }}
             onContextMenu={(e) => onChannelContextMenu(e, channel.id, channel.name)}
+            onDragOver={(e) => {
+              if (![...e.dataTransfer.types].includes(CLIENT_DRAG_MIME)) return;
+              e.preventDefault();
+              e.dataTransfer.dropEffect = "move";
+              if (dragOverChannelId !== channel.id) setDragOverChannelId(channel.id);
+            }}
+            onDragLeave={(e) => {
+              const related = e.relatedTarget as Node | null;
+              if (related && e.currentTarget.contains(related)) return;
+              setDragOverChannelId((prev) => (prev === channel.id ? null : prev));
+            }}
+            onDrop={(e) => {
+              e.preventDefault();
+              setDragOverChannelId(null);
+              const payload = parseClientDragPayload(e.dataTransfer.getData(CLIENT_DRAG_MIME));
+              if (!payload || payload.channelId === channel.id) return;
+              onMoveClient(payload.clientId, channel.id);
+            }}
             title={t("tree.clickToJoin")}
           >
             {!spacer.isSpacer && (
@@ -816,6 +881,18 @@ function ChannelTree({
                         ? " ts-talking"
                         : ""
                     }${selected?.type === "client" && selected.id === c.id ? " ts-row-selected" : ""}`}
+                    draggable
+                    onDragStart={(e) => {
+                      const payload: ClientDragPayload = {
+                        clientId: c.id,
+                        channelId: c.channel,
+                      };
+                      const raw = JSON.stringify(payload);
+                      e.dataTransfer.setData(CLIENT_DRAG_MIME, raw);
+                      e.dataTransfer.setData("text/plain", raw);
+                      e.dataTransfer.effectAllowed = "move";
+                    }}
+                    onDragEnd={() => setDragOverChannelId(null)}
                     onClick={() => onSelectItem({ type: "client", id: c.id })}
                     onDoubleClick={
                       c.id === ownClientId ? undefined : () => onOpenPrivateChat(c.id, c.name)
@@ -904,6 +981,7 @@ function ChannelTree({
               onSwitchChannel={onSwitchChannel}
               onOpenPrivateChat={onOpenPrivateChat}
               onPokeClient={onPokeClient}
+              onMoveClient={onMoveClient}
               onClientContextMenu={onClientContextMenu}
               onChannelContextMenu={onChannelContextMenu}
             />
@@ -1470,6 +1548,7 @@ function FavoritesDialog({
           id: crypto.randomUUID(),
           bookmarkName: prefillNew.host || t("favorites.newFavoriteName"),
           ...prefillNew,
+          showServerQueryClients: prefillNew.showServerQueryClients === true,
         }
       : null
   );
@@ -1496,6 +1575,7 @@ function FavoritesDialog({
       serverPassword: "",
       defaultChannel: "",
       defaultChannelPassword: "",
+      showServerQueryClients: false,
     };
     setDraft((prev) => [...prev, nf]);
     setSelectedId(nf.id);
@@ -1624,7 +1704,12 @@ function FavoritesDialog({
               </select>
             </label>
             <label className="ts-dialog-checkbox">
-              <input type="checkbox" disabled defaultChecked title="Not supported yet" />
+              <input
+                type="checkbox"
+                disabled={!selected}
+                checked={selected?.showServerQueryClients ?? false}
+                onChange={(e) => updateSelected({ showServerQueryClients: e.target.checked })}
+              />
               {t("favorites.showServerQueryClients")}
             </label>
             <label className="ts-dialog-checkbox">
@@ -2250,6 +2335,80 @@ function GroupAssignDialog({
                       <span className="ts-menu-item-label">{g.name}</span>
                       {kind === "server" && assigned && (
                         <span className="ts-group-assign-hint">{t("groupAssign.clickToRemove")}</span>
+                      )}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+        <div className="ts-dialog-buttons">
+          <div />
+          <div className="ts-dialog-buttons-right">
+            <button onClick={onClose}>{t("dialog.close")}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MoveClientDialog({
+  clientName,
+  currentChannelId,
+  channels,
+  onSelect,
+  onClose,
+}: {
+  clientName: string;
+  currentChannelId: number;
+  channels: ChannelInfo[];
+  onSelect: (channelId: number) => void;
+  onClose: () => void;
+}) {
+  const t = useT();
+  const backdrop = useBackdropDismiss(onClose);
+  const movable = [...channels].sort((a, b) => a.order - b.order);
+
+  return (
+    <div className="ts-dialog-backdrop" {...backdrop}>
+      <div className="ts-dialog ts-group-assign-dialog" onClick={(e) => e.stopPropagation()}>
+        <div className="ts-dialog-titlebar">
+          <span>
+            {t("moveClient.title")} - {clientName}
+          </span>
+          <button onClick={onClose} title={t("dialog.close")}>
+            ✕
+          </button>
+        </div>
+        <div className="ts-dialog-body">
+          {movable.length === 0 ? (
+            <div className="ts-connection-info-loading">{t("moveClient.empty")}</div>
+          ) : (
+            <ul className="ts-group-assign-list">
+              {movable.map((ch) => {
+                const current = ch.id === currentChannelId;
+                const spacer = spacerDisplayName(ch.name, ch.parent === 0);
+                const label = spacer.isSpacer
+                  ? spacer.label.trim() || ch.name
+                  : ch.name;
+                return (
+                  <li key={ch.id}>
+                    <button
+                      className={`ts-menu-item${current ? " ts-group-assign-current" : ""}`}
+                      disabled={current}
+                      onClick={() => onSelect(ch.id)}
+                    >
+                      <span className="ts-menu-item-icon">
+                        {current ? "✔️" : spacer.isSpacer ? "➖" : "📁"}
+                      </span>
+                      <span className="ts-menu-item-label">{label}</span>
+                      {current && (
+                        <span className="ts-group-assign-hint">{t("moveClient.current")}</span>
+                      )}
+                      {!current && spacer.isSpacer && (
+                        <span className="ts-group-assign-hint">{t("moveClient.spacer")}</span>
                       )}
                     </button>
                   </li>
@@ -4950,6 +5109,11 @@ function AppInner() {
     clientId: number;
     clientName: string;
   } | null>(null);
+  const [moveClientTarget, setMoveClientTarget] = useState<{
+    clientId: number;
+    clientName: string;
+    channelId: number;
+  } | null>(null);
   const [permissionOverviewOpen, setPermissionOverviewOpen] = useState(false);
   const [permissionOverview, setPermissionOverview] = useState<PermissionOverviewEntry[] | null>(null);
   const [permissionsEditorOpen, setPermissionsEditorOpen] = useState(false);
@@ -5084,6 +5248,8 @@ function AppInner() {
   const [novaMenuOpen, setNovaMenuOpen] = useState(false);
   const novaMenuRef = useRef<HTMLDivElement | null>(null);
   const [favorites, setFavorites] = useState<Favorite[]>(() => loadFavorites());
+  /** Favorite that opened the active session tab; drives ServerQuery visibility. */
+  const [activeFavoriteId, setActiveFavoriteId] = useState<string | null>(null);
   const [favoritesMenuOpen, setFavoritesMenuOpen] = useState(false);
   const [favoritesDialogMode, setFavoritesDialogMode] = useState<
     { kind: "add"; prefill: Omit<Favorite, "id" | "bookmarkName"> } | { kind: "manage" } | null
@@ -5392,6 +5558,7 @@ function AppInner() {
       hasConnected: hasConnectedRef.current,
       previousClients: previousClientsRef.current,
       micWasOn: micOn,
+      favoriteId: activeFavoriteId,
     });
 
   const applyParkedToUi = (parked: ParkedSessionState) => {
@@ -5417,6 +5584,7 @@ function AppInner() {
     setServerChat(parked.serverChat);
     setPmThreads(parked.pmThreads);
     setPokes(parked.pokes);
+    setActiveFavoriteId(parked.favoriteId);
     setActiveTab(parked.chatTab);
     setTalkers(new Set(parked.talkers));
     setWhisperChannelIds(new Set(parked.whisperChannelIds));
@@ -5468,6 +5636,7 @@ function AppInner() {
     hasConnectedRef.current = false;
     previousClientsRef.current = null;
     cleanDisconnectRef.current = false;
+    setActiveFavoriteId(null);
   };
 
   // serverGroups/channelGroups/permissionCatalog/banList/fileBrowser* are
@@ -5597,6 +5766,7 @@ function AppInner() {
     defaultChannel?: string;
     privilegeKey?: string;
     serverType?: ServerType;
+    favoriteId?: string | null;
   }) => {
     const connectHost = overrides?.host ?? host;
     const connectNickname = overrides?.nickname ?? nickname;
@@ -5605,6 +5775,7 @@ function AppInner() {
     const connectDefaultChannel = overrides?.defaultChannel ?? defaultChannel;
     const connectPrivilegeKey = overrides?.privilegeKey ?? privilegeKey;
     const connectServerType = overrides?.serverType ?? serverType;
+    const connectFavoriteId = overrides?.favoriteId !== undefined ? overrides.favoriteId : null;
 
     // Multi-join: keep existing sessions; park the active tab and open a new one.
     if (activeSessionIdRef.current && sessionsRef.current.has(activeSessionIdRef.current)) {
@@ -5612,6 +5783,7 @@ function AppInner() {
     }
 
     clearActiveUi();
+    setActiveFavoriteId(connectFavoriteId);
     hasConnectedRef.current = false;
     setConnecting(true);
     setConnectError(null);
@@ -5660,7 +5832,11 @@ function AppInner() {
         const rec = sessionsRef.current.get(sessionId);
         if (!rec) return;
         if (!rec.parked) {
-          rec.parked = emptyParkedState({ host: connectHost, nickname: connectNickname });
+          rec.parked = emptyParkedState({
+            host: connectHost,
+            nickname: connectNickname,
+            favoriteId: connectFavoriteId,
+          });
         }
         if (data.type === "disconnected") {
           sessionsRef.current.delete(sessionId);
@@ -5731,8 +5907,13 @@ function AppInner() {
           if (prevClients) {
             const prevIds = new Set(prevClients.map((c) => c.id));
             const newIds = new Set(newClients.map((c) => c.id));
-            const joined = newClients.some((c) => !prevIds.has(c.id) && c.name !== connectNickname);
-            const left = prevClients.some((c) => !newIds.has(c.id) && c.name !== connectNickname);
+            // ServerQuery churn is noisy; never play join/leave for those clients.
+            const joined = newClients.some(
+              (c) => !prevIds.has(c.id) && c.name !== connectNickname && !c.isQuery
+            );
+            const left = prevClients.some(
+              (c) => !newIds.has(c.id) && c.name !== connectNickname && !c.isQuery
+            );
             if (joined) void playSound("clientJoin");
             if (left) void playSound("clientLeave");
           }
@@ -6071,12 +6252,14 @@ function AppInner() {
       serverPassword: f.serverPassword,
       channelPassword: f.defaultChannelPassword,
       defaultChannel: f.defaultChannel,
+      favoriteId: f.id,
     });
   };
 
   const saveFavorites = (next: Favorite[]) => {
-    setFavorites(next);
-    localStorage.setItem(FAVORITES_KEY, JSON.stringify(next));
+    const normalized = next.map((f) => normalizeFavorite(f));
+    setFavorites(normalized);
+    localStorage.setItem(FAVORITES_KEY, JSON.stringify(normalized));
   };
 
   const openAddFavorite = () => {
@@ -6088,6 +6271,7 @@ function AppInner() {
         serverPassword,
         defaultChannel,
         defaultChannelPassword: channelPassword,
+        showServerQueryClients: false,
       },
     });
     setFavoritesMenuOpen(false);
@@ -6993,6 +7177,33 @@ function AppInner() {
     socketRef.current?.send(JSON.stringify({ type: "getChannelGroupList" }));
   };
 
+  const handleShowMoveClient = (clientId: number, clientName: string) => {
+    const target = clients.find((c) => c.id === clientId);
+    setMoveClientTarget({
+      clientId,
+      clientName,
+      channelId: target?.channel ?? 0,
+    });
+  };
+
+  const handleMoveClient = (clientId: number, channelId: number) => {
+    const client = clients.find((c) => c.id === clientId);
+    if (client && client.channel === channelId) return;
+    socketRef.current?.send(
+      JSON.stringify({
+        type: "moveClient",
+        clientId,
+        channelId,
+      })
+    );
+  };
+
+  const handleMoveClientToChannel = (channelId: number) => {
+    if (!moveClientTarget) return;
+    handleMoveClient(moveClientTarget.clientId, channelId);
+    setMoveClientTarget(null);
+  };
+
   const handleShowServerGroupAssign = (clientId: number, clientName: string) => {
     setGroupAssignTarget({ kind: "server", clientId, clientName });
     setServerGroups(null);
@@ -7267,6 +7478,18 @@ function AppInner() {
     selfActive && !inputMuted && ownClient?.hasTalkPower
       ? new Set(talkers).add(ownClient.id)
       : talkers;
+  const showServerQueryClients =
+    activeFavoriteId != null &&
+    favorites.some((f) => f.id === activeFavoriteId && f.showServerQueryClients);
+  const treeClients = showServerQueryClients ? clients : clients.filter((c) => !c.isQuery);
+  const queryClientCount = clients.reduce((n, c) => n + (c.isQuery ? 1 : 0), 0);
+  const displayClientCount = showServerQueryClients
+    ? serverClientsOnline > 0
+      ? serverClientsOnline + queryClientCount
+      : treeClients.length
+    : serverClientsOnline > 0
+      ? serverClientsOnline
+      : treeClients.length;
   const novaSplash = designTheme === "nova" && !connected;
 
   return (
@@ -8163,6 +8386,16 @@ function AppInner() {
         />
       )}
 
+      {moveClientTarget && (
+        <MoveClientDialog
+          clientName={moveClientTarget.clientName}
+          currentChannelId={moveClientTarget.channelId}
+          channels={channels}
+          onSelect={handleMoveClientToChannel}
+          onClose={() => setMoveClientTarget(null)}
+        />
+      )}
+
       {permissionOverviewOpen && (
         <PermissionOverviewDialog
           entries={permissionOverview}
@@ -8465,6 +8698,18 @@ function AppInner() {
             <span className="ts-menu-item-icon">👉</span>
             <span className="ts-menu-item-label">{t("clientContext.poke")}</span>
           </button>
+          {!clientContextMenu.isSelf && (
+            <button
+              className="ts-menu-item"
+              onClick={() => {
+                handleShowMoveClient(clientContextMenu.clientId, clientContextMenu.clientName);
+                setClientContextMenu(null);
+              }}
+            >
+              <span className="ts-menu-item-icon">🚚</span>
+              <span className="ts-menu-item-label">{t("clientContext.moveTo")}</span>
+            </button>
+          )}
           <button
             className="ts-menu-item"
             onClick={() => {
@@ -8726,7 +8971,7 @@ function AppInner() {
                 </div>
                 <ChannelTree
                   channels={channels}
-                  clients={clients}
+                  clients={treeClients}
                   parent={0}
                   ownClientId={ownClientId ?? ownClient?.id ?? null}
                   talkers={displayTalkers}
@@ -8738,6 +8983,7 @@ function AppInner() {
                   onSwitchChannel={handleSwitchChannel}
                   onOpenPrivateChat={handleOpenPrivateChat}
                   onPokeClient={handlePokeClient}
+                  onMoveClient={handleMoveClient}
                   onClientContextMenu={handleClientContextMenu}
                   onChannelContextMenu={handleChannelContextMenu}
                 />
@@ -8764,14 +9010,12 @@ function AppInner() {
                 serverVersion={serverVersion}
                 serverLicense={serverLicense}
                 serverLicenseId={serverLicenseId}
-                totalClientCount={
-                  serverClientsOnline > 0 ? serverClientsOnline : clients.length
-                }
+                totalClientCount={displayClientCount}
                 totalChannelCount={
                   serverChannelsOnline > 0 ? serverChannelsOnline : channels.length
                 }
                 channels={channels}
-                clients={clients}
+                clients={treeClients}
                 serverGroups={serverGroups}
                 onShowServerConnectionInfo={handleShowServerConnectionInfo}
                 onEditServer={() => setServerEditOpen(true)}
@@ -8784,7 +9028,7 @@ function AppInner() {
 
         <div className="ts-chat-panel">
           {connected && designTheme === "pulse" && (
-            <SpeakingNowBar clients={clients} talkers={displayTalkers} ownClientId={ownClient?.id ?? null} />
+            <SpeakingNowBar clients={treeClients} talkers={displayTalkers} ownClientId={ownClient?.id ?? null} />
           )}
           <div className="ts-chat-messages">
             {activeTab === "channel"

--- a/web/src/connectionSessions.ts
+++ b/web/src/connectionSessions.ts
@@ -50,6 +50,8 @@ export type ClientInfo = {
   channelGroup: number;
   serverGroups: number[];
   hasTalkPower: boolean;
+  /** ServerQuery client; hidden in the tree unless the favorite enables them. */
+  isQuery?: boolean;
 };
 
 export type WhisperLogEntry = {
@@ -92,6 +94,8 @@ export type ParkedSessionState = {
   previousClients: ClientInfo[] | null;
   /** Whether the mic was on for this tab when it was parked, so switching back restores it. */
   micWasOn: boolean;
+  /** Favorite used to open this session (drives ServerQuery visibility). */
+  favoriteId: string | null;
 };
 
 export type SessionTabInfo = {
@@ -143,6 +147,7 @@ export function emptyParkedState(partial?: Partial<ParkedSessionState>): ParkedS
     hasConnected: false,
     previousClients: null,
     micWasOn: false,
+    favoriteId: null,
     ...partial,
   };
 }

--- a/web/src/demoMode.ts
+++ b/web/src/demoMode.ts
@@ -277,6 +277,20 @@ export class DemoSocket {
         );
         break;
       }
+      case "moveClient": {
+        const clientId = Number(msg.clientId);
+        const channelId = Number(msg.channelId);
+        if (Number.isFinite(clientId) && Number.isFinite(channelId)) {
+          if (clientId === SELF_ID) {
+            this.selfChannel = channelId;
+          } else {
+            const npc = DEMO_NPCS.find((c) => c.id === clientId);
+            if (npc) npc.channel = channelId;
+          }
+          this.after(120, () => this.sendChannels(this.lastNickname));
+        }
+        break;
+      }
       case "getClientConnectionInfo": {
         this.after(400, () =>
           this.emit({

--- a/web/src/i18n.tsx
+++ b/web/src/i18n.tsx
@@ -521,6 +521,7 @@ const translations: Record<Lang, Record<string, string>> = {
 
     "clientContext.privateChat": "Privater Chat",
     "clientContext.poke": "Anstupsen",
+    "clientContext.moveTo": "Verschieben in…",
     "clientContext.copyName": "Namen kopieren",
     "clientContext.connectionInfo": "Verbindungsinformationen anzeigen",
     "clientContext.addWhisperTarget": "Als Whisper-Ziel hinzufügen",
@@ -531,6 +532,11 @@ const translations: Record<Lang, Record<string, string>> = {
     "clientContext.kick": "Vom Server kicken",
     "clientContext.ban": "Bannen",
     "clientContext.notSupported": "Im Web-Client noch nicht unterstützt",
+
+    "moveClient.title": "Verschieben",
+    "moveClient.empty": "Keine Channels verfügbar.",
+    "moveClient.current": "Aktueller Channel",
+    "moveClient.spacer": "Spacer",
 
     "serverContext.connectionInfo": "Serververbindungsinformationen",
     "serverContext.copyAddress": "Serveradresse kopieren",
@@ -1081,6 +1087,7 @@ const translations: Record<Lang, Record<string, string>> = {
 
     "clientContext.privateChat": "Private chat",
     "clientContext.poke": "Poke",
+    "clientContext.moveTo": "Move to…",
     "clientContext.copyName": "Copy name",
     "clientContext.connectionInfo": "Show connection info",
     "clientContext.addWhisperTarget": "Add as whisper target",
@@ -1091,6 +1098,11 @@ const translations: Record<Lang, Record<string, string>> = {
     "clientContext.kick": "Kick from server",
     "clientContext.ban": "Ban",
     "clientContext.notSupported": "Not yet supported in the web client",
+
+    "moveClient.title": "Move",
+    "moveClient.empty": "No channels available.",
+    "moveClient.current": "Current channel",
+    "moveClient.spacer": "Spacer",
 
     "serverContext.connectionInfo": "Server Connection Info",
     "serverContext.copyAddress": "Copy server address",

--- a/web/src/locales/zh-CN.ts
+++ b/web/src/locales/zh-CN.ts
@@ -486,6 +486,7 @@ export const zhCN: Record<string, string> = {
 
   "clientContext.privateChat": "私聊",
   "clientContext.poke": "戳一戳",
+  "clientContext.moveTo": "移动到…",
   "clientContext.copyName": "复制名称",
   "clientContext.connectionInfo": "查看连接信息",
   "clientContext.addWhisperTarget": "添加为悄悄话目标",
@@ -496,6 +497,11 @@ export const zhCN: Record<string, string> = {
   "clientContext.kick": "踢出服务器",
   "clientContext.ban": "封禁",
   "clientContext.notSupported": "网页客户端暂不支持此功能",
+
+  "moveClient.title": "移动",
+  "moveClient.empty": "没有可用频道。",
+  "moveClient.current": "当前频道",
+  "moveClient.spacer": "间隔频道",
 
   "serverContext.connectionInfo": "服务器连接信息",
   "serverContext.copyAddress": "复制服务器地址",

--- a/web/src/styles/greenteaspeak.css
+++ b/web/src/styles/greenteaspeak.css
@@ -652,6 +652,13 @@
   padding-right: 0;
 }
 
+.ts-app.ts-design-greenteaspeak .ts-channel-row.ts-drop-target,
+.ts-app.ts-design-greenteaspeak .ts-channel-row.ts-spacer.ts-drop-target {
+  background: color-mix(in srgb, var(--accent, #4caf50) 28%, transparent);
+  outline: 1px dashed var(--accent, #4caf50);
+  outline-offset: -1px;
+}
+
 .ts-app.ts-design-greenteaspeak .ts-channel-row.ts-spacer .ts-spacer-label {
   left: 4px;
   right: 4px;


### PR DESCRIPTION
Merges #5 (client move/DnD, ServerQuery favorite toggle, TeaSpeak poke handling) together with the review fixes from GreenTeaSpeak/webspeak3#2:

1. `handleMoveClient`: self-drags now route through `handleSwitchChannel` so moving your own client still prompts for a channel password when required, while admin moves of other clients keep bypassing the target channel's password (native TS3/GTS behavior).
2. `MoveClientDialog`: channel spacers disabled as move targets.
3. connector `moveclient` handler: fallback branch now forwards the decoded password instead of hardcoding an empty one.
4. `treeClients`/`queryClientCount` memoized; `displayClientCount` ternary simplified.

Supersedes #5 - verified: frontend (`npx tsc -b`) and connector (`cargo check`) both build cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)